### PR TITLE
pass a event-fn instead of a component-system to watch-fn

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject me.lomin/component-restart "0.1.2"
+(defproject me.lomin/component-restart "0.2.0"
             :description "A simple watcher that restarts components when files change."
             :url "https://github.com/lomin/component-restart"
             :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject me.lomin/component-restart "0.2.0"
+(defproject kaibra/component-restart "0.2.0"
             :description "A simple watcher that restarts components when files change."
-            :url "https://github.com/lomin/component-restart"
+            :url "https://github.com/kaibra/component-restart"
             :license {:name "Eclipse Public License"
                       :url "http://www.eclipse.org/legal/epl-v10.html"}
             :dependencies [[org.clojure/clojure "1.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,5 @@
                       :url "http://www.eclipse.org/legal/epl-v10.html"}
             :dependencies [[org.clojure/clojure "1.6.0"]
                            [org.clojure/tools.logging "0.3.1"]
-                           [org.clojure/tools.namespace "0.2.10"]
-                           [com.stuartsierra/component  "0.2.3"]])
+                           [org.clojure/tools.namespace "0.2.10"]])
 

--- a/src/me/lomin/component_restart.clj
+++ b/src/me/lomin/component_restart.clj
@@ -3,8 +3,7 @@
             [clojure.tools.logging :as log]
             [clojure.tools.namespace.dir :as dir]
             [clojure.tools.namespace.repl :as repl]
-            [clojure.tools.namespace.track :as track]
-            [com.stuartsierra.component :as component]))
+            [clojure.tools.namespace.track :as track]))
 
 (defn- to-relative-resource [a-meta]
   (string/join "." (pop (string/split (:file a-meta) #"\."))))
@@ -37,13 +36,13 @@
     ((resolve-callback a-meta))))
 
 (defn watch
-  ([callback-var system]
-   (watch callback-var system (dir/scan (track/tracker))))
-  ([callback-var system tracker]
+  ([callback-var event-fn]
+   (watch callback-var event-fn (dir/scan (track/tracker))))
+  ([callback-var event-fn tracker]
   (let [new-tracker (dir/scan tracker)]
     (if (not= new-tracker tracker)
       (do
-        (component/stop system)
+        (event-fn)
         (reload callback-var))
       (do (Thread/sleep 200)
-        (recur callback-var system new-tracker))))))
+        (recur callback-var event-fn new-tracker))))))

--- a/test/me/lomin/package_with_underscores/component_restart_test.clj
+++ b/test/me/lomin/package_with_underscores/component_restart_test.clj
@@ -1,5 +1,6 @@
 (ns me.lomin.package-with-underscores.component-restart-test
   (:require [clojure.test :refer :all]
+            [me.lomin.package-with-underscores.some-test :as st]
             [me.lomin.component-restart :as cr]))
 
 (defn constant-three []
@@ -13,3 +14,21 @@
            (cr/ns-symbol a-meta)))
     (is (= (var constant-three)
            (cr/resolve-callback (meta (var constant-three)))))))
+
+
+(deftest watching
+  (testing "call event-fn"
+    (let [called (atom false)
+          event-fn (fn [] (reset! called true))
+          some-test "test/me/lomin/package_with_underscores/some_test.clj"
+          original-content (slurp some-test)]
+      (with-redefs [cr/reload (constantly nil)]
+        (try
+          (let [f (future
+                    (dotimes [n 10]
+                      (Thread/sleep 100)
+                      (spit some-test "(ns me.lomin.package-with-underscores.some-test)\n\n\n(defn somefoo [] :foo)")))]
+            (cr/watch (var st/somefoo) event-fn)
+            (is (= true @called)))
+          (finally
+            (spit some-test original-content)))))))

--- a/test/me/lomin/package_with_underscores/some_test.clj
+++ b/test/me/lomin/package_with_underscores/some_test.clj
@@ -1,0 +1,4 @@
+(ns me.lomin.package-with-underscores.some-test)
+
+
+(defn somefoo [] :foo)


### PR DESCRIPTION
Just thought, this could be more generic by passing a event-fn to the watch-function.
This way your lib also supports mount for example.

Let me know what you think.

Kai